### PR TITLE
Convert a stateful (int) seed into a stateless (tuple) seed in `sampl…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 
 ## [Unreleased]
 
+## [1.1.6] - 2025-07-14
+
+* Convert stateful seeds into stateless seeds in `sample_posterior()` to ensure
+  the sampling is deterministic.
+
 ## [1.1.5] - 2025-07-10
 
 * Remove `sigma_dims` pseudo-dimension from inference data.
@@ -342,4 +347,5 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 [1.1.3]: https://github.com/google/meridian/releases/tag/v1.1.3
 [1.1.4]: https://github.com/google/meridian/releases/tag/v1.1.4
 [1.1.5]: https://github.com/google/meridian/releases/tag/v1.1.5
-[Unreleased]: https://github.com/google/meridian/compare/v1.1.5...HEAD
+[1.1.6]: https://github.com/google/meridian/releases/tag/v1.1.6
+[Unreleased]: https://github.com/google/meridian/compare/v1.1.6...HEAD

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ To cite this repository:
   author = {Google Meridian Marketing Mix Modeling Team},
   title = {Meridian: Marketing Mix Modeling},
   url = {https://github.com/google/meridian},
-  version = {1.1.5},
+  version = {1.1.6},
   year = {2025},
 }
 ```

--- a/meridian/model/posterior_sampler.py
+++ b/meridian/model/posterior_sampler.py
@@ -528,7 +528,7 @@ class PosteriorMCMCSampler:
         be a positive integer. For more information, see `tf.while_loop`.
       seed: An `int32[2]` Tensor or a Python list or tuple of 2 `int`s, which
         will be treated as stateless seeds; or a Python `int` or `None`, which
-        will be treated as stateful seeds. See [tfp.random.sanitize_seed]
+        will be converted into a stateless seed. See [tfp.random.sanitize_seed]
         (https://www.tensorflow.org/probability/api_docs/python/tfp/random/sanitize_seed).
       **pins: These are used to condition the provided joint distribution, and
         are passed directly to `joint_dist.experimental_pin(**pins)`.
@@ -547,6 +547,8 @@ class PosteriorMCMCSampler:
           " [tfp.random.sanitize_seed](https://www.tensorflow.org/probability/api_docs/python/tfp/random/sanitize_seed)"
           " for details."
       )
+    if seed is not None and isinstance(seed, int):
+      seed = (seed, seed)
     seed = tfp.random.sanitize_seed(seed) if seed is not None else None
     n_chains_list = [n_chains] if isinstance(n_chains, int) else n_chains
     total_chains = np.sum(n_chains_list)

--- a/meridian/version.py
+++ b/meridian/version.py
@@ -14,4 +14,4 @@
 
 """Module for Meridian version."""
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"


### PR DESCRIPTION
…e_posterior` to ensure the sampling is deterministic.

PiperOrigin-RevId: 783094677