### PR TITLE
Add diagnostics utility module

### DIFF
--- a/meridian/david/diagnostics.py
+++ b/meridian/david/diagnostics.py
@@ -1,0 +1,150 @@
+"""Posterior diagnostics utilities for Meridian.
+
+This module provides simple helper functions to compute common
+statistical diagnostics from the posterior draws of a fitted
+``Meridian`` model.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, Optional, Union
+
+import arviz as az
+import numpy as np
+import pandas as pd
+from scipy.stats import jarque_bera as _jarque_bera
+
+
+# --------------------------------------------------------------------
+# 1. Posterior mean, standard deviation and credible interval
+# --------------------------------------------------------------------
+
+def posterior_summary(
+    idata: az.InferenceData,
+    var_name: str,
+    coord: Optional[Dict[str, Union[str, int]]] = None,
+    cred_mass: float = 0.95,
+) -> Dict[str, float]:
+  """Summary statistics for a single scalar posterior.
+
+  Parameters
+  ----------
+  idata:
+    ArviZ ``InferenceData`` returned by ``Meridian.sample_posterior``.
+  var_name:
+    Name of the variable to summarize, e.g. ``"beta_m"``.
+  coord:
+    Optional mapping selecting a single coefficient, for example
+    ``{"media": "media_channel_1"}``.
+  cred_mass:
+    Width of the central credible interval. ``0.95`` by default.
+
+  Returns
+  -------
+  dict
+    Keys ``mean``, ``sd``, ``t_stat`` and the bounds of the requested
+    credible interval.
+  """
+  da = idata.posterior[var_name]
+  if coord:
+    da = da.sel(**coord)
+  samples = da.values.reshape(-1)
+
+  mean = float(samples.mean())
+  sd = float(samples.std(ddof=1))
+  t = mean / sd
+
+  alpha = 1.0 - cred_mass
+  lo, hi = np.quantile(samples, [alpha / 2, 1.0 - alpha / 2])
+  ci_key_lo = f"{cred_mass * 100:.1f}%_ci_lower"
+  ci_key_hi = f"{cred_mass * 100:.1f}%_ci_upper"
+
+  return {
+      "mean": mean,
+      "sd": sd,
+      "t_stat": t,
+      ci_key_lo: float(lo),
+      ci_key_hi: float(hi),
+  }
+
+
+# --------------------------------------------------------------------
+# 2. Variance inflation factors
+# --------------------------------------------------------------------
+
+def compute_vif(X: Union[np.ndarray, pd.DataFrame]) -> pd.Series:
+  """Computes OLS-style variance inflation factors for each column of ``X``."""
+  if isinstance(X, np.ndarray):
+    X_mat = X
+    columns = [f"x{i}" for i in range(X.shape[1])]
+  else:
+    X_mat = X.values
+    columns = list(X.columns)
+
+  vifs = []
+  for j in range(X_mat.shape[1]):
+    y = X_mat[:, j]
+    X_other = np.delete(X_mat, j, axis=1)
+    coef, *_ = np.linalg.lstsq(X_other, y, rcond=None)
+    y_hat = X_other @ coef
+    ssr = np.sum((y - y_hat) ** 2)
+    sst = np.sum((y - y.mean()) ** 2)
+    r2 = 1.0 - ssr / sst
+    vifs.append(1.0 / (1.0 - r2 + 1e-12))
+
+  return pd.Series(vifs, index=columns, name="VIF")
+
+
+# --------------------------------------------------------------------
+# 3. Durbin-Watson statistic
+# --------------------------------------------------------------------
+
+def durbin_watson(residuals: np.ndarray) -> float:
+  """First-order autocorrelation diagnostic."""
+  residuals = np.asarray(residuals).ravel()
+  diff = np.diff(residuals)
+  return float(np.sum(diff ** 2) / np.sum(residuals ** 2))
+
+
+# --------------------------------------------------------------------
+# 4. Jarque-Bera normality test
+# --------------------------------------------------------------------
+
+def jarque_bera(residuals: np.ndarray):
+  """Returns the Jarque-Bera statistic and p-value."""
+  return _jarque_bera(np.asarray(residuals).ravel())
+
+
+# --------------------------------------------------------------------
+# 5. Mass-above-threshold test
+# --------------------------------------------------------------------
+
+def mass_above_threshold(
+    idata: az.InferenceData,
+    var_name: str,
+    coord: dict | None = None,
+    cred_mass: float = 0.95,
+    *,
+    threshold: float | None = None,
+    log_space: bool = False,
+) -> dict[str, float | bool]:
+  """Probability that a coefficient exceeds a threshold."""
+  da = idata.posterior[var_name]
+  if coord:
+    da = da.sel(**coord)
+  samples = da.values.reshape(-1)
+
+  if log_space:
+    samples = np.log(samples)
+
+  if threshold is None:
+    threshold = 0.0
+
+  prob_above = np.mean(samples > threshold)
+
+  return {
+      "prob_above": float(prob_above),
+      "meets_cred": bool(prob_above >= cred_mass),
+      "cred_mass_req": float(cred_mass),
+      "threshold": float(threshold),
+  }

--- a/meridian/david/diagnostics_test.py
+++ b/meridian/david/diagnostics_test.py
@@ -1,0 +1,80 @@
+import arviz as az
+import numpy as np
+import pandas as pd
+from absl.testing import absltest
+
+from meridian.david import diagnostics
+
+
+class PosteriorSummaryTest(absltest.TestCase):
+
+  def test_basic_stats(self):
+    arr = np.array([[0.5, 1.0, 1.5, 2.0]])
+    idata = az.from_dict(posterior={"beta_m": arr[:, :, None]})
+    result = diagnostics.posterior_summary(idata, "beta_m")
+    samples = arr.reshape(-1)
+    mean = samples.mean()
+    sd = samples.std(ddof=1)
+    t = mean / sd
+    alpha = 0.05
+    lo, hi = np.quantile(samples, [alpha / 2, 1 - alpha / 2])
+    self.assertAlmostEqual(result["mean"], mean)
+    self.assertAlmostEqual(result["sd"], sd)
+    self.assertAlmostEqual(result["t_stat"], t)
+    self.assertAlmostEqual(result["95.0%_ci_lower"], lo)
+    self.assertAlmostEqual(result["95.0%_ci_upper"], hi)
+
+
+class ComputeVifTest(absltest.TestCase):
+
+  def test_vif_values(self):
+    X = pd.DataFrame({"a": [1, 0, 1], "b": [0, 1, 1]})
+    result = diagnostics.compute_vif(X)
+    expected = []
+    for j in range(X.shape[1]):
+      y = X.iloc[:, j].values
+      X_other = X.drop(X.columns[j], axis=1).values
+      coef, *_ = np.linalg.lstsq(X_other, y, rcond=None)
+      y_hat = X_other @ coef
+      ssr = np.sum((y - y_hat) ** 2)
+      sst = np.sum((y - y.mean()) ** 2)
+      r2 = 1.0 - ssr / sst
+      expected.append(1.0 / (1.0 - r2 + 1e-12))
+    np.testing.assert_allclose(result.values, np.array(expected))
+
+
+class DurbinWatsonTest(absltest.TestCase):
+
+  def test_statistic(self):
+    residuals = np.array([0.5, 0.1, -0.3, 0.2])
+    diff = np.diff(residuals)
+    expected = np.sum(diff ** 2) / np.sum(residuals ** 2)
+    self.assertAlmostEqual(diagnostics.durbin_watson(residuals), expected)
+
+
+class JarqueBeraTest(absltest.TestCase):
+
+  def test_statistic(self):
+    residuals = np.array([0.5, 0.1, -0.3, 0.2])
+    stat, p = diagnostics.jarque_bera(residuals)
+    self.assertGreaterEqual(stat, 0.0)
+    self.assertGreaterEqual(p, 0.0)
+    self.assertLessEqual(p, 1.0)
+
+
+class MassAboveThresholdTest(absltest.TestCase):
+
+  def test_prob_above(self):
+    arr = np.array([[0.9, 1.1, 1.2, 0.8]])
+    idata = az.from_dict(posterior={"beta_m": arr[:, :, None]})
+    result = diagnostics.mass_above_threshold(
+        idata, "beta_m", cred_mass=0.95, log_space=True
+    )
+    samples = np.log(arr.reshape(-1))
+    prob = np.mean(samples > 0.0)
+    self.assertAlmostEqual(result["prob_above"], prob)
+    self.assertEqual(result["meets_cred"], prob >= 0.95)
+
+
+if __name__ == "__main__":
+  absltest.main()


### PR DESCRIPTION
## Summary
- add diagnostics utilities for beta_m posteriors in david package
- unit tests for the new diagnostics functions

## Testing
- `pytest meridian/david/diagnostics_test.py -q` *(fails: No module named 'arviz')*

------
https://chatgpt.com/codex/tasks/task_b_6877c718be0883218ffcb80070d54f6e