### PR TITLE
Add diagnostics utilities and stub

### DIFF
--- a/immutabledict.py
+++ b/immutabledict.py
@@ -1,0 +1,19 @@
+class immutabledict(dict):
+    """Simple immutable dict implementation for tests."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+    def _blocked(self, *args, **kwargs):
+        raise TypeError("immutabledict is immutable")
+
+    __setitem__ = _blocked
+    __delitem__ = _blocked
+    clear = _blocked
+    pop = _blocked
+    popitem = _blocked
+    setdefault = _blocked
+    update = _blocked
+
+    def __hash__(self):
+        return hash(tuple(sorted(self.items())))


### PR DESCRIPTION
## Summary
- expand `diagnostics.py` with VIF computation, posterior summaries, and more
- add optional pandas import and new helper for series diagnostics
- provide lightweight `immutabledict` stub for tests

## Testing
- `pytest meridian/diagnostics_test.py -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_b_6878f1a8dfb48321a31c7097693ed2e7