### PR TITLE
Add fixed actual-vs-fitted helper

### DIFF
--- a/meridian/david/values.py
+++ b/meridian/david/values.py
@@ -89,6 +89,32 @@ def get_actual_vs_fitted_data(
   return fit_ds.to_dataframe().reset_index()
 
 
+# ---------------------------------------------------------------------------
+# 4. Actual-vs-fitted outcome data (API-compatible wrapper)
+# ---------------------------------------------------------------------------
+def get_actual_vs_fitted_data_fixed(
+    mmm,
+    *,
+    confidence_level: float = 0.90,
+    aggregate_geos: bool = False,
+    aggregate_times: bool = False,
+    selected_times: Sequence[str | int] | None = None,
+) -> pd.DataFrame:
+  """Wrapper for ``Analyzer.expected_vs_actual_data`` removing deprecated args."""
+
+  ana = analyzer.Analyzer(mmm)
+  fit_ds: xr.Dataset = ana.expected_vs_actual_data(
+      confidence_level=confidence_level,
+      aggregate_geos=aggregate_geos,
+      aggregate_times=aggregate_times,
+  )
+
+  if selected_times is not None:
+    fit_ds = fit_ds.sel(time=selected_times)
+
+  return fit_ds.to_dataframe().reset_index()
+
+
 if __name__ == "__main__":
   curves = get_curve_parameter_data(mmm)
   curves.to_csv("hill_curve_parameters.csv", index=False)
@@ -96,5 +122,5 @@ if __name__ == "__main__":
   opt = get_budget_optimisation_data(mmm, selected_channels=["YouTube"])
   opt.to_csv("rf_budget_optimisation.csv", index=False)
 
-  avf = get_actual_vs_fitted_data(mmm, aggregate_geos=True)
+  avf = get_actual_vs_fitted_data_fixed(mmm, aggregate_geos=True)
   avf.to_csv("actual_vs_fitted.csv", index=False)

--- a/meridian/david/values_test.py
+++ b/meridian/david/values_test.py
@@ -66,30 +66,28 @@ class GetBudgetOptimisationDataTest(absltest.TestCase):
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
 
-class GetActualVsFittedDataTest(absltest.TestCase):
+
+class GetActualVsFittedDataFixedTest(absltest.TestCase):
 
   def test_calls_analyzer_and_returns_dataframe(self):
     mmm = object()
-    ds = xr.Dataset({"x": (['t'], [1, 2])}, coords={"t": [0, 1]})
+    ds = xr.Dataset({"x": (['time'], [1, 2])}, coords={"time": ['a', 'b']})
     with mock.patch.object(values.analyzer, 'Analyzer') as MockAnalyzer:
       MockAnalyzer.return_value.expected_vs_actual_data.return_value = ds
-      result = values.get_actual_vs_fitted_data(
+      result = values.get_actual_vs_fitted_data_fixed(
           mmm,
           confidence_level=0.8,
           aggregate_geos=True,
           aggregate_times=True,
-          selected_geos=['g'],
-          selected_times=['t'],
+          selected_times=['a'],
       )
       MockAnalyzer.assert_called_once_with(mmm)
       MockAnalyzer.return_value.expected_vs_actual_data.assert_called_once_with(
           confidence_level=0.8,
           aggregate_geos=True,
           aggregate_times=True,
-          selected_geos=['g'],
-          selected_times=['t'],
       )
-    expected = ds.to_dataframe().reset_index()
+    expected = ds.sel(time=['a']).to_dataframe().reset_index()
     pd.testing.assert_frame_equal(result, expected)
 
 


### PR DESCRIPTION
## Summary
- provide `get_actual_vs_fitted_data_fixed` wrapper avoiding deprecated args
- use new helper in `__main__`
- update tests for the wrapper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*
- `pip install tensorflow==2.18` *(fails: connection blocked)*

------
https://chatgpt.com/codex/tasks/task_b_6878fa24a958832188f05e214fda2cb3