### PR TITLE
Implement pull_load_purge helper

### DIFF
--- a/meridian/david/s3.py
+++ b/meridian/david/s3.py
@@ -8,7 +8,8 @@ results in a browser.
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Optional
+from typing import Any, Callable, Optional
+from urllib.parse import urlparse
 
 import boto3
 import shutil
@@ -16,6 +17,7 @@ import traceback
 
 __all__ = [
     "push_and_purge",
+    "pull_load_purge",
     "generate_presigned_url",
     "display_html_link",
 ]
@@ -86,4 +88,43 @@ def display_html_link(bucket: str, key: str, expires_in: int = 3600):
 
     url = generate_presigned_url(bucket=bucket, key=key, expires_in=expires_in)
     return HTML(f'<a href="{url}" target="_blank">Open report in new tab</a>')
+
+
+def pull_load_purge(
+    s3_uri: str,
+    loader_fn: Callable[[str | Path], Any],
+    tmp_dir: str | Path = "input_tmp",
+) -> Any:
+    """Download ``s3_uri`` and load it with ``loader_fn``.
+
+    The file is downloaded to ``tmp_dir`` and removed afterwards. The
+    returned value is whatever ``loader_fn`` returns.
+    """
+    parsed = urlparse(s3_uri)
+    if parsed.scheme != "s3":
+        raise ValueError(f"Expected s3:// URI, got {s3_uri!r}")
+
+    bucket, key = parsed.netloc, parsed.path.lstrip("/")
+
+    tmp_dir = Path(tmp_dir)
+    tmp_dir.mkdir(exist_ok=True)
+    local = tmp_dir / Path(key).name
+
+    s3 = boto3.client("s3")
+    try:
+        s3.download_file(bucket, key, str(local))
+        print(f"Downloaded {s3_uri} to {local}")
+        obj = loader_fn(local)
+        print("Object loaded.")
+        return obj
+    except Exception:
+        traceback.print_exc()
+        raise
+    finally:
+        try:
+            local.unlink(missing_ok=True)
+            tmp_dir.rmdir()
+        except OSError:
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+        print(f"Removed temporary directory {tmp_dir}")
 


### PR DESCRIPTION
## Summary
- add pull_load_purge to download and load an object from S3
- test the new helper and update __all__

## Testing
- `python -m py_compile meridian/david/s3.py meridian/david/s3_test.py`
- `pytest meridian/david/s3_test.py -k PullLoadPurgeTest -q` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_b_6880bf9da0f48321a77a5b21b5248c98