### PR TITLE
Fix plot_posterior_coef quoting

### DIFF
--- a/meridian/david/betas.py
+++ b/meridian/david/betas.py
@@ -197,20 +197,22 @@ def plot_posterior_coef(
   import pandas as pd, altair as alt
   alt.data_transformers.disable_max_rows()  # avoid silent truncation
 
-  col = f"{parameter}[{index}]"
-  df = pd.DataFrame({col: samples})
+  col_name = f"{parameter}[{index}]"
+  df = pd.DataFrame({col_name: samples})
+
+  field = f"`{col_name}`:Q"
 
   return (
       alt.Chart(df)
       .mark_bar(opacity=0.7)
       .encode(
-          x=alt.X(f"{col}:Q", bin=alt.Bin(maxbins=maxbins)),
+          x=alt.X(field, bin=alt.Bin(maxbins=maxbins)),
           y="count()",
       )
       .properties(
           width=width,
           height=height,
-          title=f"Posterior of {col} (log scale)",
+          title=f"Posterior of {col_name} (log scale)",
       )
   )
 

--- a/meridian/david/betas_test.py
+++ b/meridian/david/betas_test.py
@@ -329,9 +329,10 @@ class PlotPosteriorCoefTest(absltest.TestCase):
     self.assertEqual(chart.properties_args.get('width'), 300)
     self.assertEqual(chart.properties_args.get('height'), 100)
     self.assertEqual(list(chart.data.columns), ['a[1]'])
-    # Ensure encoding used the provided maxbins.
+    # Ensure encoding used the provided maxbins and quoted field name.
     _, enc_kwargs = chart.encode_args
     self.assertEqual(enc_kwargs['x']['bin']['maxbins'], 20)
+    self.assertEqual(enc_kwargs['x']['field'], '`a[1]`:Q')
 
 
 class OptimalFreqSafeTest(absltest.TestCase):


### PR DESCRIPTION
## Summary
- ensure `plot_posterior_coef` properly quotes field names
- test that the field name used by Altair contains backticks

## Testing
- `pytest meridian/david/betas_test.py::PlotPosteriorCoefTest::test_returns_chart -q` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_b_6881f3a13f548321905f5fd75a859442