### PR TITLE
Add timestamp option to S3 uploader

### DIFF
--- a/meridian/david/s3.py
+++ b/meridian/david/s3.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable, Optional
 from urllib.parse import urlparse
+from datetime import datetime
 
 import boto3
 import shutil
@@ -30,6 +31,8 @@ def push_and_purge(
     team_prefix: str,
     user_space: str,
     file_structure: str,
+    *,
+    add_timestamp: bool = False,
 ) -> None:
     """Upload a file to S3 and remove the temporary directory.
 
@@ -52,7 +55,15 @@ def push_and_purge(
     local = out_dir / file_name
 
     prefix = f"{team_prefix.rstrip('/')}/{user_space.strip('/')}/{file_structure.strip('/')}/"
-    s3_key = f"{prefix}{file_name}"
+
+    if add_timestamp:
+        ts = datetime.utcnow().strftime("%Y%m%dT%H%M%S")
+        path = Path(file_name)
+        remote_name = f"{path.stem}_{ts}{path.suffix}"
+    else:
+        remote_name = file_name
+
+    s3_key = f"{prefix}{remote_name}"
     s3 = boto3.client("s3")
 
     try:


### PR DESCRIPTION
## Summary
- add `add_timestamp` option to `push_and_purge`
- test timestamped behaviour

## Testing
- `pytest -q meridian/david/s3_test.py::PushAndPurgeTest::test_timestamped_upload` *(fails: ModuleNotFoundError: No module named 'absl')*

------
https://chatgpt.com/codex/tasks/task_b_688241b995e8832192f2b860450e9c1b