### PR TITLE
Handle different time dimensions in design matrix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ To release a new version (e.g. from `1.0.0` -> `2.0.0`):
 -->
 
 ## [Unreleased]
+* ``build_design_matrix()`` now detects the temporal dimension name and
+  supports ``"time"``, ``"media_time"`` and ``"geo_time"``.
 
 ## [1.1.7] - 2025-07-16
 


### PR DESCRIPTION
## Summary
- make `build_design_matrix` detect time dimension
- expose helper `_infer_time_dim`
- update tests for time-dimension agnostic logic
- document new behaviour in CHANGELOG

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tensorflow')*

------
https://chatgpt.com/codex/tasks/task_b_688c98999ab48321aab4c3ae049bb9b7