### PR TITLE
Fix orientation bug in design matrix builder

### DIFF
--- a/meridian/david/diagnostics.py
+++ b/meridian/david/diagnostics.py
@@ -227,8 +227,10 @@ def build_design_matrix(
 
   if controls_da is not None:
     tdim_ctrl = _infer_time_dim(controls_da)
+    ctrl_dim = next(d for d in controls_da.dims if d not in ("geo", tdim_ctrl))
     ctrl_df = (
         controls_da.stack(sample=("geo", tdim_ctrl))
+        .transpose("sample", ctrl_dim)
         .to_pandas()
     )
     X = pd.concat([media_df, ctrl_df], axis=1)

--- a/meridian/david/diagnostics_test.py
+++ b/meridian/david/diagnostics_test.py
@@ -108,9 +108,25 @@ class BuildDesignMatrixTest(absltest.TestCase):
         )
         ctrl_df = (
             controls.stack(sample=("geo", "media_time"))
+            .transpose("sample", "control")
             .to_pandas()
         )
         expected = pd.concat([media_df, ctrl_df], axis=1)
+        expected.insert(0, "const", 1.0)
+        expected = expected.astype("float64")
+        pdt.assert_frame_equal(result, expected)
+
+    def test_matrix_without_controls(self):
+        media = xr.DataArray(
+            np.arange(8).reshape(1, 2, 4),
+            dims=("geo", "media_time", "media_channel"),
+        )
+        result = diagnostics.build_design_matrix(media)
+        expected = (
+            media.stack(sample=("geo", "media_time"))
+            .transpose("sample", "media_channel")
+            .to_pandas()
+        )
         expected.insert(0, "const", 1.0)
         expected = expected.astype("float64")
         pdt.assert_frame_equal(result, expected)


### PR DESCRIPTION
## Summary
- ensure controls are oriented with samples on rows
- update design matrix tests to verify orientation and add check without controls

## Testing
- `pytest meridian/david/diagnostics_test.py::BuildDesignMatrixTest::test_matrix_construction -q` *(fails: found no collectors)*
- `python meridian/david/diagnostics_test.py` *(fails: ModuleNotFoundError: No module named 'arviz')*


------
https://chatgpt.com/codex/tasks/task_b_688c9e286568832198ebeb944cc24e56