### PR TITLE
Fix posterior coefficient plotting for Altair

### DIFF
--- a/meridian/david/betas_test.py
+++ b/meridian/david/betas_test.py
@@ -420,14 +420,14 @@ class PlotPosteriorCoefTest(absltest.TestCase):
     m = DummyMeridian(posterior)
     chart = betas.plot_posterior_coef(m, 'a', 1, maxbins=20, width=300, height=100)
     self.assertIsInstance(chart, alt.Chart)
-    self.assertEqual(chart.properties_args.get('title'), 'Posterior of a[1] (log scale)')
+    self.assertEqual(chart.properties_args.get('title'), 'Posterior of a[1]')
     self.assertEqual(chart.properties_args.get('width'), 300)
     self.assertEqual(chart.properties_args.get('height'), 100)
-    self.assertEqual(list(chart.data.columns), ['a[1]'])
-    # Ensure encoding used the provided maxbins and quoted field name.
+    self.assertEqual(list(chart.data.columns), ['value'])
+    # Ensure encoding used the provided maxbins and safe field name.
     _, enc_kwargs = chart.encode_args
     self.assertEqual(enc_kwargs['x']['bin']['maxbins'], 20)
-    self.assertEqual(enc_kwargs['x']['field'], '`a[1]`:Q')
+    self.assertEqual(enc_kwargs['x']['field'], 'value:Q')
 
 
 class OptimalFreqSafeTest(absltest.TestCase):


### PR DESCRIPTION
## Summary
- use safe `value` column in `plot_posterior_coef` to avoid Vega-Lite field parsing issues
- adjust tests for new column name and title

## Testing
- `PYTHONPATH=$PWD pytest meridian/david/betas_test.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'statsmodels'; No module named 'boto3'; No module named 'mlflow')*


------
https://chatgpt.com/codex/tasks/task_b_68b6e65e89a08321a031fe964acbcd86