### PR TITLE
Improve coordinate handling in mass_above_threshold diagnostic

### DIFF
--- a/meridian/david/diagnostics.py
+++ b/meridian/david/diagnostics.py
@@ -293,7 +293,18 @@ def mass_above_threshold(
     """Probability that a coefficient exceeds a threshold."""
     da = idata.posterior[var_name]
     if coord:
-        da = da.sel(**coord)
+        try:
+            da = da.sel(**coord)
+        except KeyError as err:  # pragma: no cover - xarray raises KeyError
+            dim, val = next(iter(coord.items()))
+            if dim not in da.dims:
+                raise KeyError(
+                    f"Dimension {dim!r} not found; available dims: {list(da.dims)}"
+                ) from err
+            choices = list(da[dim].values)
+            raise KeyError(
+                f"Value {val!r} not found in coordinate {dim!r}; choices: {choices}"
+            ) from err
     samples = da.values.reshape(-1)
 
     if log_space:

--- a/meridian/david/diagnostics_test.py
+++ b/meridian/david/diagnostics_test.py
@@ -134,6 +134,18 @@ class MassAboveThresholdTest(absltest.TestCase):
         self.assertAlmostEqual(result["prob_above"], prob)
         self.assertEqual(result["meets_cred"], prob >= 0.95)
 
+    def test_missing_coord_value_raises(self):
+        arr = np.array([[[0.9, 1.1], [1.2, 0.8]]])  # shape (chain, draw, media)
+        idata = az.from_dict(
+            posterior={"beta_m": arr},
+            coords={"media_channel": ["a", "b"]},
+            dims={"beta_m": ["media_channel"]},
+        )
+        with self.assertRaisesRegex(KeyError, "media_channel"):
+            diagnostics.mass_above_threshold(
+                idata, "beta_m", coord={"media_channel": "c"}
+            )
+
 
 class AugmentedDickeyFullerTest(absltest.TestCase):
 


### PR DESCRIPTION
## Summary
- handle missing coordinate dimensions/labels in `mass_above_threshold`
- add regression test for invalid coordinate handling

## Testing
- `PYTHONPATH=. pytest meridian/david/diagnostics_test.py::MassAboveThresholdTest::test_missing_coord_value_raises -q`
- `pytest` *(fails: ERROR meridian/david/s3_test.py, ERROR meridian/mlflow/autolog_test.py)*

------
https://chatgpt.com/codex/tasks/task_b_68b81c9946208321902e1cc0c5364a64