### PR TITLE
feat: extract Hill posterior parameters for individual channels

### DIFF
--- a/meridian/david/values.py
+++ b/meridian/david/values.py
@@ -3,13 +3,155 @@
 from __future__ import annotations
 
 from collections.abc import Sequence
+from typing import Any, Dict, Optional, Union, Sequence as Seq
 
+import numpy as np
 import pandas as pd
 import tensorflow as tf
 import xarray as xr
 
 from meridian.analysis import analyzer
 from meridian import constants as C
+
+
+# ---------------------------------------------------------------------------
+# Utility functions for working with Hill parameters
+# ---------------------------------------------------------------------------
+ArrayLike = Union[np.ndarray, "tf.Tensor"]
+
+
+def _to_numpy(x: ArrayLike | None) -> np.ndarray | None:
+  """Convert ``tf.Tensor`` or Python containers to ``np.ndarray`` without copy."""
+  if x is None:
+    return None
+  if isinstance(x, np.ndarray):
+    return x
+  if isinstance(x, (tf.Tensor, tf.Variable)):
+    return x.numpy()
+  return np.asarray(x)
+
+
+def extract_hill_posterior(
+    transformer: Any | None = None,
+    *,
+    ec: ArrayLike | None = None,
+    slope: ArrayLike | None = None,
+    channel: int | str = 0,
+    channel_names: Seq[str] | None = None,
+    flatten_samples: bool = True,
+    quantiles: Seq[float] = (0.05, 0.5, 0.95),
+) -> Dict[str, Any]:
+  """Extract posterior samples and summaries for Hill ``ec`` and ``slope``.
+
+  Parameters ``ec`` and ``slope`` are arrays whose final dimension indexes the
+  media channel.  Leading dimensions correspond to arbitrary sample batches
+  (e.g., ``[n_chains, n_draws]``).  ``channel`` may be an integer index or a
+  channel name when ``channel_names`` is provided.
+  """
+
+  if transformer is not None:
+    if ec is None and hasattr(transformer, "ec"):
+      ec = getattr(transformer, "ec")
+    if slope is None and hasattr(transformer, "slope"):
+      slope = getattr(transformer, "slope")
+
+  if ec is None or slope is None:
+    raise ValueError(
+        "Provide either a trained `transformer` or both `ec` and `slope` arrays/tensors."
+    )
+
+  ec_np = _to_numpy(ec)
+  slope_np = _to_numpy(slope)
+
+  if ec_np.shape != slope_np.shape:
+    raise ValueError("`ec` and `slope` shapes must match; got " f"{ec_np.shape} vs {slope_np.shape}.")
+  if ec_np.ndim < 1:
+    raise ValueError("`ec`/`slope` must have at least 1 dimension; last dimension is channels.")
+
+  n_channels = ec_np.shape[-1]
+
+  if isinstance(channel, (str, bytes)):
+    if channel_names is None:
+      raise ValueError("When `channel` is a string, `channel_names` must be given.")
+    try:
+      channel_index = int(list(channel_names).index(channel))
+    except ValueError as e:
+      raise ValueError(
+          f"Channel name {channel!r} not found in channel_names={list(channel_names)!r}."
+      ) from e
+  else:
+    channel_index = int(channel)
+    if channel_index < 0:
+      channel_index += n_channels
+    if not 0 <= channel_index < n_channels:
+      raise ValueError(
+          f"`channel` index out of range: {channel_index} for n_channels={n_channels}."
+      )
+
+  ec_ch = ec_np[..., channel_index]
+  slope_ch = slope_np[..., channel_index]
+
+  if flatten_samples:
+    ec_samples = ec_ch.reshape(-1)
+    slope_samples = slope_ch.reshape(-1)
+  else:
+    ec_samples = ec_ch
+    slope_samples = slope_ch
+
+  def _summ(x: np.ndarray) -> Dict[str, Any]:
+    x = np.asarray(x, dtype=float)
+    return {
+        "mean": float(np.mean(x)),
+        "sd": float(np.std(x, ddof=0)),
+        "quantiles": {float(q): float(np.quantile(x, q)) for q in quantiles},
+    }
+
+  return {
+      "channel_index": channel_index,
+      "channel_name": (list(channel_names)[channel_index] if channel_names is not None else None),
+      "samples": {"ec": ec_samples, "slope": slope_samples},
+      "summary": {"ec": _summ(ec_samples), "slope": _summ(slope_samples)},
+  }
+
+
+def hill_curve_quantiles(
+    media_grid: ArrayLike,
+    ec_samples: ArrayLike,
+    slope_samples: ArrayLike,
+    quantiles: Seq[float] = (0.05, 0.5, 0.95),
+) -> Dict[str, Any]:
+  """Evaluate Hill curves for posterior samples and summarise over a media grid."""
+  m = np.atleast_1d(_to_numpy(media_grid)).astype(float)
+  if m.ndim != 1:
+    raise ValueError("`media_grid` must be 1D.")
+  if np.any(m < 0):
+    raise ValueError("`media_grid` must be non-negative.")
+
+  ec_s = np.ravel(_to_numpy(ec_samples)).astype(float)
+  sl_s = np.ravel(_to_numpy(slope_samples)).astype(float)
+  if ec_s.shape != sl_s.shape:
+    raise ValueError("`ec_samples` and `slope_samples` must have the same length.")
+
+  log_ec = np.log(np.maximum(ec_s, 1e-300))[:, None]
+  log_m = np.where(m[None, :] > 0.0, np.log(m[None, :]), -np.inf)
+  logit = sl_s[:, None] * (log_ec - log_m)
+
+  out = np.empty_like(logit)
+  pos = logit >= 0
+  neg = ~pos
+  out[pos] = 1.0 / (1.0 + np.exp(logit[pos]))
+  expx = np.exp(logit[neg])
+  out[neg] = expx / (1.0 + expx)
+
+  zero_mask = (m == 0.0)[None, :]
+  if np.any(zero_mask):
+    sl_b = sl_s[:, None]
+    y_zero = np.where(sl_b == 0.0, 0.5, 0.0)
+    out = np.where(zero_mask, y_zero, out)
+
+  mean = np.mean(out, axis=0)
+  qdict = {float(q): np.quantile(out, q, axis=0) for q in quantiles}
+  return {"media": m, "mean": mean, "quantiles": qdict}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `extract_hill_posterior` utility to surface Hill ec and slope samples for a chosen media channel
- add `hill_curve_quantiles` helper to evaluate response curves from those samples
- exercise new helpers with dedicated tests

## Testing
- `PYTHONPATH=. pytest meridian/david/values_test.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b81eda7d208321ac513238f361ad87