### PR TITLE
Allow passing observed data to Durbin-Watson helper

### DIFF
--- a/meridian/david/diagnostics.py
+++ b/meridian/david/diagnostics.py
@@ -237,9 +237,14 @@ def durbin_watson_from_idata(
     time_dim: str | None = None,
     by: tuple[str, ...] | None = None,
     reduce_over: tuple[str, ...] = ("chain", "draw"),
+    observed: xr.DataArray | None = None,
 ):
-    """DW from an InferenceData, preferring posterior_predictive but falling back
-    to ``predictions`` or deterministic posterior variables (e.g., kpi_hat, mu_kpi).
+    """DW from an InferenceData.
+
+    Prefer ``posterior_predictive`` but fall back to ``predictions`` or
+    deterministic posterior variables (e.g., ``kpi_hat``, ``mu_kpi``). When the
+    InferenceData lacks an ``observed_data`` group, ``observed`` may be supplied
+    directly.
 
     Example
     -------
@@ -253,6 +258,9 @@ def durbin_watson_from_idata(
         return da.mean(keep) if keep else da
 
     def _pick_observed_var():
+        if observed is not None:
+            name = getattr(observed, "name", None) or target_priority[0]
+            return name, observed
         if not hasattr(idata, "observed_data"):
             raise AttributeError("InferenceData has no observed_data group.")
         for v in target_priority:

--- a/meridian/david/test_diagnostics.py
+++ b/meridian/david/test_diagnostics.py
@@ -44,6 +44,18 @@ def test_durbin_watson_from_idata_posterior_predictive():
   assert np.isclose(dw, _expected_dw(yobs, np.ones(3)))
 
 
+def test_durbin_watson_from_idata_manual_observed():
+  yobs = _base_observed()
+  yhat = xr.DataArray(
+      np.ones((2, 2, 3)), dims=("chain", "draw", "time")
+  )
+  idata = az.InferenceData(
+      posterior_predictive=xr.Dataset({"kpi": yhat})
+  )
+  dw = diagnostics.durbin_watson_from_idata(idata, observed=yobs)
+  assert np.isclose(dw, _expected_dw(yobs, np.ones(3)))
+
+
 def test_durbin_watson_from_idata_predictions_fallback():
   yobs = _base_observed()
   yhat = xr.DataArray(np.ones((2, 3)), dims=("draw", "time"))


### PR DESCRIPTION
## Summary
- extend `durbin_watson_from_idata` with an optional `observed` argument to supply observations when `InferenceData` lacks an `observed_data` group
- add tests covering the manual observed-data path

## Testing
- `python -m pytest meridian/david/diagnostics_test.py meridian/david/test_diagnostics.py`
- `python -m pytest` *(fails: ERROR meridian/david/s3_test.py, ERROR meridian/mlflow/autolog_test.py)*

------
https://chatgpt.com/codex/tasks/task_b_68b85818bce483219d48e98dda37a3b1