### PR TITLE
Handle missing reach/frequency data in budget optimisation

### DIFF
--- a/meridian/david/values_test.py
+++ b/meridian/david/values_test.py
@@ -164,6 +164,25 @@ class GetBudgetOptimisationDataTest(absltest.TestCase):
                          values.C.ROI, values.C.OPTIMAL_FREQUENCY]]
     pd.testing.assert_frame_equal(result.reset_index(drop=True), expected)
 
+  def test_returns_empty_dataframe_when_no_rf_data(self):
+    class DummyMMM:
+      pass
+
+    mmm = DummyMMM()
+    # No rf_tensors or rf data present
+    mmm.rf_tensors = mock.Mock(rf_impressions=None, rf_spend=None)
+
+    result = values.get_budget_optimisation_data(mmm)
+    expected = pd.DataFrame(
+        columns=[
+            values.C.RF_CHANNEL,
+            values.C.FREQUENCY,
+            values.C.ROI,
+            values.C.OPTIMAL_FREQUENCY,
+        ]
+    )
+    pd.testing.assert_frame_equal(result, expected)
+
 
 
 class GetActualVsFittedDataFixedTest(absltest.TestCase):


### PR DESCRIPTION
## Summary
- Avoid errors when reach/frequency tensors are missing by returning an empty table
- Skip RF export in `__main__` when model lacks RF data
- Test budget optimisation output with and without RF tensors

## Testing
- `PYTHONPATH=. pytest meridian/david/values_test.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b96a62391083218a3e4a50ceb2be0d