### PR TITLE
Include non-RF media channels in budget optimisation data

### DIFF
--- a/meridian/david/values.py
+++ b/meridian/david/values.py
@@ -177,27 +177,26 @@ def get_budget_optimisation_data(
     use_kpi: bool = False,
     confidence_level: float = 0.90,
 ) -> pd.DataFrame:
-  """Returns optimal frequency metrics as a table."""
-  rf_tensors = getattr(mmm, "rf_tensors", None)
-  # Gracefully handle models without reach/frequency tensors by returning an
-  # empty DataFrame with the expected columns. This avoids downstream
-  # ``Analyzer`` calls that would otherwise fail when RF data is absent.
-  has_impr = (
-      getattr(rf_tensors, "rf_impressions", None) is not None
-      if rf_tensors is not None
-      else False
-  )
-  has_spend = (
-      getattr(rf_tensors, "rf_spend", None) is not None
-      if rf_tensors is not None
-      else False
-  )
-  if not (has_impr or has_spend):
-    return pd.DataFrame(
-        columns=[C.RF_CHANNEL, C.FREQUENCY, C.ROI, C.OPTIMAL_FREQUENCY]
-    )
+  """Returns optimal-frequency ROI (RF) and ROI for non-RF paid media as one table.
 
+  Output schema (preserved):
+    - rf_channel: channel name (applies to both RF and non-RF)
+    - frequency: RF frequency grid value (NaN for non-RF rows)
+    - roi: mean ROI
+    - optimal_frequency: channel-level optimal frequency (NaN for non-RF rows)
+
+  Notes:
+    - For RF channels we compute ROI across the provided frequency grid and attach
+      that channel's optimal_frequency on each row.
+    - For non-RF paid media channels we compute ROI from `Analyzer.summary_metrics`
+      (mean), evaluated at the RF channels' optimal frequency (so the system is
+      consistent), and add a single row per non-RF channel with frequency/optimal_frequency = NaN.
+  """
   ana = analyzer.Analyzer(mmm)
+
+  # Build a minimal DataTensors consistent with the original code, so both
+  # optimal_freq() and summary_metrics() can reuse mmm data where not provided.
+  rf_tensors = getattr(mmm, "rf_tensors", None)
   input_data = getattr(mmm, "input_data", None)
   new_data = analyzer.DataTensors(
       rf_impressions=tf.cast(rf_tensors.rf_impressions, tf.float32)
@@ -210,48 +209,115 @@ def get_budget_optimisation_data(
       if getattr(input_data, "revenue_per_kpi", None) is not None
       else None,
   )
-  # Construct a float32 frequency grid to avoid mixed-precision errors in
-  # ``Analyzer.optimal_freq``.  Use the maximum frequency from the model data when
-  # available, otherwise fall back to a reasonable default.
+
+  # Frequency grid for RF part (if any RF channels exist).
   rf_freq = getattr(rf_tensors, "frequency", None)
   max_frequency = None
   if rf_freq is not None:
     try:
       max_frequency = float(tf.reduce_max(tf.cast(rf_freq, tf.float32)).numpy())
-    except Exception:  # numpy arrays or other array-like
+    except Exception:
       max_frequency = float(np.max(np.array(rf_freq, dtype=np.float32)))
   if not max_frequency or not np.isfinite(max_frequency):
     max_frequency = 50.0
   freq_grid = np.arange(1.0, max_frequency, 0.1, dtype=np.float32)
 
-  rf_ds: xr.Dataset = ana.optimal_freq(
+  tables: list[pd.DataFrame] = []
+
+  # ---- 1) RF block: ROI over frequency grid + optimal_frequency per RF channel.
+  rf_ds = None
+  rf_available: list[str] = []
+  try:
+    rf_ds = ana.optimal_freq(
+        new_data=new_data,
+        freq_grid=freq_grid,
+        selected_times=selected_times,
+        use_kpi=use_kpi,
+        confidence_level=confidence_level,
+    )
+    rf_available = [str(c) for c in rf_ds.coords[C.RF_CHANNEL].values]
+  except Exception:
+    rf_ds = None
+    rf_available = []
+
+  # Select RF channels, tolerating unknown labels.
+  if selected_channels is None:
+    rf_selected = rf_available
+  else:
+    rf_selected = [c for c in selected_channels if c in rf_available]
+
+  # If we have RF data and selection yields channels, build the RF table.
+  opt_freq_vec = None
+  if rf_ds is not None and rf_available:
+    # ROI(grid) for selected RF channels.
+    if rf_selected:
+      perf_df = (
+          rf_ds[[C.ROI]]
+          .sel(metric=[C.MEAN])
+          .sel(rf_channel=rf_selected)
+          .to_dataframe()
+          .reset_index()
+          .pivot(index=[C.RF_CHANNEL, C.FREQUENCY], columns=C.METRIC, values=C.ROI)
+          .reset_index()
+          .rename(columns={C.MEAN: C.ROI})
+      )
+      opt_df = (
+          rf_ds[[C.OPTIMAL_FREQUENCY]]
+          .sel(rf_channel=rf_selected)
+          .to_dataframe()
+          .reset_index()
+      )
+      rf_table = perf_df.merge(opt_df, on=C.RF_CHANNEL)
+      tables.append(rf_table)
+
+    # Keep the full optimal-frequency vector (for all RF channels) to make
+    # summary_metrics internally consistent; do not subset here.
+    opt_freq_vec = np.asarray(rf_ds[C.OPTIMAL_FREQUENCY].values, dtype=np.float32)
+
+  # ---- 2) Non-RF paid media block: ROI at (RF) optimal frequencies.
+  # Compute summary metrics with optimal_frequency applied (if known).
+  sum_ds = ana.summary_metrics(
       new_data=new_data,
-      freq_grid=freq_grid,
+      optimal_frequency=opt_freq_vec,
       selected_times=selected_times,
       use_kpi=use_kpi,
       confidence_level=confidence_level,
+      include_non_paid_channels=False,
   )
 
-  channels = (
-      selected_channels if selected_channels is not None else rf_ds.rf_channel.values
-  )
+  # All paid channels (media + rf) live on `channel`. Remove aggregate total.
+  all_paid = [str(c) for c in sum_ds.coords[C.CHANNEL].values]
+  non_total = [c for c in all_paid if c != C.ALL_CHANNELS]
 
-  perf_df = (
-      rf_ds[[C.ROI]]
-      .sel(metric=[C.MEAN])
-      .sel(rf_channel=channels)
-      .to_dataframe()
-      .reset_index()
-      .pivot(index=[C.RF_CHANNEL, C.FREQUENCY], columns=C.METRIC, values=C.ROI)
-      .reset_index()
-      .rename(columns={C.MEAN: C.ROI})
-  )
+  # Non-RF = paid channels that are not in rf_available.
+  non_rf_channels = [c for c in non_total if c not in rf_available]
+  if selected_channels is not None:
+    non_rf_channels = [c for c in non_rf_channels if c in selected_channels]
 
-  opt_df = (
-      rf_ds[[C.OPTIMAL_FREQUENCY]].sel(rf_channel=channels).to_dataframe().reset_index()
-  )
+  if non_rf_channels:
+    mdf = (
+        sum_ds[[C.ROI]]
+        .sel(metric=[C.MEAN])
+        .sel(channel=non_rf_channels)
+        .to_dataframe()
+        .reset_index()
+        .pivot(index=[C.CHANNEL], columns=C.METRIC, values=C.ROI)
+        .reset_index()
+        .rename(columns={C.MEAN: C.ROI})
+    )
+    mdf[C.FREQUENCY] = np.nan
+    mdf[C.OPTIMAL_FREQUENCY] = np.nan
+    mdf = mdf.rename(columns={C.CHANNEL: C.RF_CHANNEL})
+    mdf = mdf[[C.RF_CHANNEL, C.FREQUENCY, C.ROI, C.OPTIMAL_FREQUENCY]]
+    tables.append(mdf)
 
-  return perf_df.merge(opt_df, on=C.RF_CHANNEL)
+  # ---- 3) Combine.
+  if tables:
+    out = pd.concat(tables, ignore_index=True)
+  else:
+    out = pd.DataFrame(columns=[C.RF_CHANNEL, C.FREQUENCY, C.ROI, C.OPTIMAL_FREQUENCY])
+
+  return out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Expand `get_budget_optimisation_data` to append ROI rows for non-RF paid channels with NaN frequency fields
- Adjust budget optimisation tests to validate non-RF behaviour and no-RF edge case

## Testing
- `python -m pytest meridian/david/values_test.py::GetBudgetOptimisationDataTest::test_returns_dataframe_with_rf_and_non_rf_channels -q`
- `python -m pytest meridian/david/values_test.py::GetBudgetOptimisationDataTest::test_returns_non_rf_rows_when_no_rf_channels -q`
- `python -m pytest meridian/david/values_test.py::GetBudgetOptimisationDataTest -q`
- `python -m pytest meridian/david/values_test.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9750b82e483218d98323d49c86986