### PR TITLE
Allow helpers.py to work outside package

### DIFF
--- a/meridian/david/helpers.py
+++ b/meridian/david/helpers.py
@@ -16,7 +16,19 @@ from meridian import constants as C
 c = C  # convenience alias
 from meridian.analysis import analyzer
 
-from . import betas, diagnostics, values
+try:
+  # If helpers.py is part of a package (e.g., mypkg.helpers)
+  from . import betas, diagnostics, values
+except ImportError:
+  # If helpers.py is imported as a top-level module
+  import importlib
+  import os
+  import sys
+
+  sys.path.append(os.path.dirname(__file__))
+  betas = importlib.import_module("betas")
+  diagnostics = importlib.import_module("diagnostics")
+  values = importlib.import_module("values")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add fallback logic in helpers to import sibling modules when not in a package

## Testing
- `PYTHONPATH=. pytest meridian/david/betas_test.py meridian/david/diagnostics_test.py meridian/david/test_diagnostics.py meridian/david/values_test.py -q`
- `pip install boto3` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_b_68b9a86a6bdc8321b0b3f943eb2a1f53