### PR TITLE
Ensure control contribution uses safe time coords

### DIFF
--- a/meridian/david/decomp.py
+++ b/meridian/david/decomp.py
@@ -172,7 +172,14 @@ def control_contribution(
     coords["geo"] = [geos[i] for i in geo_idx]
     dims.append("geo")
   if not aggregate_times:
-    coords["time"] = [times[i] for i in time_idx]
+    time_labels = [times[i] for i in time_idx]
+    # xarray expects coordinate labels to be simple scalars; guard against
+    # ragged or otherwise incompatible objects (e.g. tz-aware timestamps).
+    try:
+      _ = np.asarray(time_labels)
+    except Exception:  # pragma: no cover - defensive fallback
+      time_labels = [str(label) for label in time_labels]
+    coords["time"] = time_labels
     dims.append("time")
   coords["metric"] = list(_METRICS)
   dims.append("metric")


### PR DESCRIPTION
## Summary
- ensure `control_contribution` coerces time labels to simple scalars when emitting the time coordinate so xarray can build the DataArray

## Testing
- pytest meridian/david/decomp_test.py

------
https://chatgpt.com/codex/tasks/task_b_68cc0d4aa8e883218672a2a2f6b72ec9